### PR TITLE
Fix compilation warning in posix systems.

### DIFF
--- a/lib/lua/SCsub
+++ b/lib/lua/SCsub
@@ -5,6 +5,9 @@ Import('env_modules')
 
 env_lua = env_modules.Clone()
 
+if env_lua['PLATFORM'] == 'posix':
+    env_lua.Append(CPPDEFINES='LUA_USE_POSIX')
+
 if not env.msvc:
     env_lua.Append(CFLAGS=['-O0', '-std=c99'])
 


### PR DESCRIPTION
Defines LUA_USE_POSIX on posix systems for lua lib to use the more secure mkstemp.