### PR TITLE
Fix build error when compiling using `custom_modules` build option

### DIFF
--- a/parser/SCsub
+++ b/parser/SCsub
@@ -5,7 +5,7 @@ Import('env_luascript')
 
 env_parser = env_luascript.Clone()
 
-env_parser.Append(CPPPATH = ['#modules/luascript/lib/antlr4'])
+env_parser.Append(CPPPATH = ['../lib/antlr4'])
 
 env_parser.add_source_files(env.modules_sources,'ast/*.cpp')
 env_parser.add_source_files(env.modules_sources,'generated/*.cpp')


### PR DESCRIPTION
See [`custom_modules` documentation](https://docs.godotengine.org/en/stable/development/compiling/introduction_to_the_buildsystem.html?highlight=custom_modules#custom-modules).

Current code uses Godot's absolute path (`#`) that breaks compilation if luascript is placed outside of Godot's source tree:

https://github.com/goostengine/godot-modules/runs/3174015174#step:6:1711

```
In file included from /Users/runner/work/godot-modules/godot-modules/modules/luascript/parser/generated/LuaBaseListener.cpp:5:
/Users/runner/work/godot-modules/godot-modules/modules/luascript/parser/generated/LuaBaseListener.h:7:10: fatal error: 'antlr4-runtime.h' file not found
#include "antlr4-runtime.h"
         ^~~~~~~~~~~~~~~~~~
1 error generated.
```

I suggest using relative path as suggested in this PR, or reorganizing existing code structure in the future.