### PR TITLE
msvc build fix

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -6,11 +6,10 @@ Import('env_modules')
 env_luascript = env_modules.Clone()
 
 if not env.msvc:
-    CXXFLAGS='-std=c++17'
+    env_luascript['CXXFLAGS'] = ['-std=c++17']
 else:
-    CXXFLAGS='/std:c++17'
-
-env_luascript['CXXFLAGS'] = [CXXFLAGS]
+    env_luascript['CCFLAGS'] = ['/std:c++17','/Zc:__cplusplus']
+    env_luascript.Append(CPPDEFINES=['ANTLR4CPP_STATIC'])
 
 Export('env_luascript')
 


### PR DESCRIPTION
Fixes perbone/luascript#22

ANTLR4CPP_STATIC fixes the dllexport error caused by the antlr library doing dynamic library things when actually godot seems to use static libraries for all modules on windows.

Using CCFLAGS instead of CXXFLAGS is just something I nicked from the discussion on perbone/luascript#22 .  No idea what this is about, but it works.

/Zc:__cplusplus was a rather frustrating one to track down.  Turns out on windows the __cplusplus flag historically wasn't kept up to date until recently, but it only works if you add this flag. https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-160

I've only tested this on windows with Godot 3.3.3-stable: https://github.com/godotengine/godot/tree/3.3.3-stable